### PR TITLE
fix: removed dependency on k8s-bundle in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "php": ">=8.2",
         "dealroadshow/k8s-resources": ">=1.30",
         "dealroadshow/k8s-framework": "^1.0",
-        "dealroadshow/k8s-bundle": "^1.0",
         "symfony/dependency-injection": ">=7.1",
         "symfony/http-kernel": ">=7.1",
         "symfony/console": ">=7.1",


### PR DESCRIPTION
Dependency on `dealroadshow/k8s-bundle` removed from `composer.json`, since this bundle does not requires any classes from `k8s-bundle` and adds complexity to testing feature branches of `k8s-bundle`